### PR TITLE
Replaced deprecated gulp-util

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,12 @@
 const { gulp, series, parallel, dest, src, watch } = require('gulp');
 const babel = require('gulp-babel');
+const beeper = require('beeper');
 const browserSync = require('browser-sync');
 const concat = require('gulp-concat');
 const connect = require('gulp-connect-php');
 const del = require('del');
+const log = require('fancy-log');
 const fs = require('fs');
-const gutil = require('gulp-util');
 const imagemin = require('gulp-imagemin');
 const inject = require('gulp-inject-string');
 const partialimport = require('postcss-easy-import');
@@ -99,9 +100,9 @@ async function copyConfig() {
 }
 
 async function installationDone() {
-	await gutil.beep();
-	await gutil.log(devServerReady);
-	await gutil.log(thankYou);
+	await beeper();
+	await log(devServerReady);
+	await log(thankYou);
 }
 
 exports.setup = series(cleanup, downloadWordPress);
@@ -143,7 +144,7 @@ function Reload(done) {
 
 function copyThemeDev() {
 	if (!fs.existsSync('./build')) {
-		gutil.log(buildNotFound);
+		log(buildNotFound);
 		process.exit(1);
 	} else {
 		return src('./src/theme/**').pipe(dest('./build/wordpress/wp-content/themes/' + themeName));
@@ -276,10 +277,10 @@ function zipProd() {
 	return src('./dist/themes/' + themeName + '/**/*')
 		.pipe(zip.dest('./dist/' + themeName + '.zip'))
 		.on('end', () => {
-			gutil.beep();
-			gutil.log(pluginsGenerated);
-			gutil.log(filesGenerated);
-			gutil.log(thankYou);
+			beeper();
+			log(pluginsGenerated);
+			log(filesGenerated);
+			log(thankYou);
 		});
 }
 
@@ -299,8 +300,8 @@ exports.prod = series(
 Utility Tasks
 -------------------------------------------------------------------------------------------------- */
 const onError = err => {
-	gutil.beep();
-	gutil.log(wpFy + ' - ' + errorMsg + ' ' + err.toString());
+	beeper();
+	log(wpFy + ' - ' + errorMsg + ' ' + err.toString());
 	this.emit('end');
 };
 
@@ -308,11 +309,11 @@ async function disableCron() {
 	if (fs.existsSync('./build/wordpress/wp-config.php')) {
 		await fs.readFile('./build/wordpress/wp-config.php', (err, data) => {
 			if (err) {
-				gutil.log(wpFy + ' - ' + warning + ' WP_CRON was not disabled!');
+				log(wpFy + ' - ' + warning + ' WP_CRON was not disabled!');
 			}
 			if (data) {
 				if (data.indexOf('DISABLE_WP_CRON') >= 0) {
-					gutil.log('WP_CRON is already disabled!');
+					log('WP_CRON is already disabled!');
 				} else {
 					return src('./build/wordpress/wp-config.php')
 						.pipe(inject.after("define('DB_COLLATE', '');", "\ndefine('DISABLE_WP_CRON', true);"))
@@ -333,15 +334,15 @@ exports.fresh = series(freshInstall);
 
 function Backup() {
 	if (!fs.existsSync('./build')) {
-		gutil.log(buildNotFound);
+		log(buildNotFound);
 		process.exit(1);
 	} else {
 		return src('./build/**/*')
 			.pipe(zip.dest('./backups/' + date + '.zip'))
 			.on('end', () => {
-				gutil.beep();
-				gutil.log(backupsGenerated);
-				gutil.log(thankYou);
+				beeper();
+				log(backupsGenerated);
+				log(thankYou);
 			});
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -775,6 +775,15 @@
 				"through2": "^2.0.3"
 			},
 			"dependencies": {
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -791,6 +800,17 @@
 			"requires": {
 				"normalize-path": "^2.0.1",
 				"through2": "^2.0.3"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				}
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -840,15 +860,15 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "11.13.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.6.tgz",
-			"integrity": "sha512-Xoo/EBzEe8HxTSwaZNLZjaW6M6tA/+GmD3/DZ6uo8qSaolE/9Oarko0oV1fVfrLqOz0tx0nXJB4rdD5c+vixLw==",
+			"version": "11.13.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.7.tgz",
+			"integrity": "sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg==",
 			"dev": true
 		},
 		"@types/q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-			"integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
 			"dev": true
 		},
 		"@types/unist": {
@@ -901,9 +921,9 @@
 			"dev": true
 		},
 		"ajv": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-			"integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
@@ -920,7 +940,7 @@
 		},
 		"ansi-colors": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
 			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
 			"dev": true,
 			"requires": {
@@ -1004,6 +1024,15 @@
 						"regex-not": "^1.0.0",
 						"snapdragon": "^0.8.1",
 						"to-regex": "^3.0.2"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
@@ -1103,12 +1132,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
-		},
-		"array-differ": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
 			"dev": true
 		},
 		"array-each": {
@@ -1270,9 +1293,9 @@
 			}
 		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
 		"async-each-series": {
@@ -1320,62 +1343,6 @@
 				"num2fraction": "^1.2.2",
 				"postcss": "^7.0.14",
 				"postcss-value-parser": "^3.3.1"
-			},
-			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30000962",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz",
-					"integrity": "sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==",
-					"dev": true
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"aws-sign2": {
@@ -1497,9 +1464,9 @@
 			"dev": true
 		},
 		"base64-js": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-			"integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
 			"dev": true,
 			"optional": true
 		},
@@ -1525,10 +1492,13 @@
 			}
 		},
 		"beeper": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-			"dev": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-2.0.0.tgz",
+			"integrity": "sha512-+ShExQEewPvKdTUOtCAJmkUAgEyNF0QqgiAhPRE5xLvoFkIPt8xuHKaz1gMLzSMS73beHWs9gbRBngdH61nVWw==",
+			"dev": true,
+			"requires": {
+				"delay": "^4.1.0"
+			}
 		},
 		"better-assert": {
 			"version": "1.0.2",
@@ -1566,7 +1536,7 @@
 		},
 		"bin-version": {
 			"version": "1.0.4",
-			"resolved": "http://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
 			"integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
 			"dev": true,
 			"requires": {
@@ -1575,7 +1545,7 @@
 		},
 		"bin-version-check": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
 			"integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
 			"dev": true,
 			"requires": {
@@ -1587,7 +1557,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "4.3.6",
-					"resolved": "http://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
 					"integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
 					"dev": true
 				}
@@ -1609,16 +1579,16 @@
 			},
 			"dependencies": {
 				"array-uniq": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
-					"integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+					"integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
 					"dev": true,
 					"optional": true
 				},
 				"bin-version": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-3.0.0.tgz",
-					"integrity": "sha512-Ekhwm6AUiMbZ1LgVCNMkgjovpMR30FyQN74laAW9gs0NPjZR5gdY0ARNB0YsQG8GOme3CsHbxmeyq/7Ofq6QYQ==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-3.1.0.tgz",
+					"integrity": "sha512-Mkfm4iE1VFt4xd4vH+gx+0/71esbfus2LsnCGe8Pi4mndSPyT+NGES/Eg99jx8/lUGWfu3z2yuB/bt5UB+iVbQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1675,7 +1645,7 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "3.0.0",
-							"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 							"dev": true,
 							"optional": true
@@ -1705,14 +1675,21 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"file-type": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+					"integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
+					"dev": true,
+					"optional": true
+				},
 				"find-versions": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.0.0.tgz",
-					"integrity": "sha512-IUvtItVFNmTtKoB0PRfbkR0zR9XMG5rWNO3qI1S8L0zdv+v2gqzM0pAunloxqbqAfT8w7bg8n/5gHzTXte8H5A==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.1.0.tgz",
+					"integrity": "sha512-NCTfNiVzeE/xL+roNDffGuRbrWI6atI18lTJ22vKp7rs2OhYzMK3W1dIdO2TUndH/QMcacM4d1uWwgcZcHK69Q==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"array-uniq": "^2.0.0",
+						"array-uniq": "^2.1.0",
 						"semver-regex": "^2.0.0"
 					}
 				},
@@ -1754,7 +1731,7 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "3.0.0",
-							"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 							"dev": true,
 							"optional": true
@@ -1770,15 +1747,15 @@
 				},
 				"p-cancelable": {
 					"version": "0.4.1",
-					"resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
 					"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
 					"dev": true,
 					"optional": true
 				},
 				"p-event": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-event/-/p-event-2.1.0.tgz",
-					"integrity": "sha512-sDEpDVnzLGlJj3k590uUdpfEUySP5yAYlvfTCu5hTDvSTXQVecYWKcEwdO49PrZlnJ5wkfAvtawnno/jyXeqvA==",
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
+					"integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1840,14 +1817,14 @@
 			}
 		},
 		"binary-extensions": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
 		"bl": {
 			"version": "1.2.2",
-			"resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
 			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
 			"dev": true,
 			"optional": true,
@@ -1980,14 +1957,6 @@
 				"caniuse-lite": "^1.0.30000960",
 				"electron-to-chromium": "^1.3.124",
 				"node-releases": "^1.1.14"
-			},
-			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30000962",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz",
-					"integrity": "sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==",
-					"dev": true
-				}
 			}
 		},
 		"bs-recipes": {
@@ -2003,24 +1972,14 @@
 			"dev": true
 		},
 		"buffer": {
-			"version": "3.6.0",
-			"resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-			"integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+			"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"base64-js": "0.0.8",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true,
-					"optional": true
-				}
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
 			}
 		},
 		"buffer-alloc": {
@@ -2064,12 +2023,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
-		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
 		"bytes": {
@@ -2199,7 +2152,7 @@
 		},
 		"camelcase-keys": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
@@ -2228,9 +2181,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000918",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000918.tgz",
-			"integrity": "sha512-CAZ9QXGViBvhHnmIHhsTPSWFBujDaelKnUj7wwImbyQRxmXynYqKGi3UaZTSz9MoVh+1EVxOS/DFIkrJYgR3aw==",
+			"version": "1.0.30000962",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz",
+			"integrity": "sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==",
 			"dev": true
 		},
 		"caseless": {
@@ -2259,9 +2212,9 @@
 			"dev": true
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
@@ -2294,24 +2247,23 @@
 			"dev": true
 		},
 		"chokidar": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
+			"integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
-				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.2.2",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
 				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.1",
+				"inherits": "^2.0.3",
 				"is-binary-path": "^1.0.0",
 				"is-glob": "^4.0.0",
-				"lodash.debounce": "^4.0.8",
-				"normalize-path": "^2.1.1",
+				"normalize-path": "^3.0.0",
 				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.5"
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.1"
 			}
 		},
 		"class-utils": {
@@ -2435,17 +2387,6 @@
 				"arr-map": "^2.0.2",
 				"for-own": "^1.0.0",
 				"make-iterator": "^1.0.0"
-			},
-			"dependencies": {
-				"for-own": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				}
 			}
 		},
 		"collection-visit": {
@@ -2459,9 +2400,9 @@
 			}
 		},
 		"color": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
-			"integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
+			"integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
 			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.1",
@@ -2497,12 +2438,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-			"dev": true
-		},
-		"colors": {
-			"version": "1.1.2",
-			"resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
 			"dev": true
 		},
 		"combined-stream": {
@@ -2627,11 +2562,14 @@
 			"optional": true
 		},
 		"content-disposition": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"requires": {
+				"safe-buffer": "5.1.2"
+			}
 		},
 		"convert-source-map": {
 			"version": "1.6.0",
@@ -2665,27 +2603,35 @@
 			}
 		},
 		"core-js": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.0.tgz",
-			"integrity": "sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
+			"integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.0.tgz",
-			"integrity": "sha512-W/Ppz34uUme3LmXWjMgFlYyGnbo1hd9JvA0LNQ4EmieqVjg2GPYbj3H6tcdP2QGPGWdRKUqZVbVKLNIFVs/HiA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.1.tgz",
+			"integrity": "sha512-2pC3e+Ht/1/gD7Sim/sqzvRplMiRnFQVlPpDVaHtY9l7zZP7knamr3VRD6NyGfHd84MrDC0tAM9ulNxYMW0T3g==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.5.1",
-				"core-js": "3.0.0",
-				"core-js-pure": "3.0.0",
-				"semver": "^5.6.0"
+				"browserslist": "^4.5.4",
+				"core-js": "3.0.1",
+				"core-js-pure": "3.0.1",
+				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"dev": true
+				}
 			}
 		},
 		"core-js-pure": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.0.tgz",
-			"integrity": "sha512-yPiS3fQd842RZDgo/TAKGgS0f3p2nxssF1H65DIZvZv0Od5CygP8puHXn3IQiM/39VAvgCbdaMQpresrbGgt9g==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.1.tgz",
+			"integrity": "sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -2695,14 +2641,14 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
-			"integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+			"integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
 			"dev": true,
 			"requires": {
 				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
+				"js-yaml": "^3.13.0",
 				"parse-json": "^4.0.0"
 			},
 			"dependencies": {
@@ -2835,9 +2781,9 @@
 			"dev": true
 		},
 		"css-what": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
-			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
 			"dev": true
 		},
 		"cssdb": {
@@ -2961,7 +2907,7 @@
 		},
 		"d": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"dev": true,
 			"requires": {
@@ -2976,12 +2922,6 @@
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
-		},
-		"dateformat": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-			"dev": true
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -3143,14 +3083,14 @@
 			"dependencies": {
 				"file-type": {
 					"version": "3.9.0",
-					"resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
 					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
 					"dev": true,
 					"optional": true
 				},
 				"get-stream": {
 					"version": "2.3.1",
-					"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
 					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
 					"dev": true,
 					"optional": true,
@@ -3253,17 +3193,14 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
 				}
 			}
+		},
+		"delay": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/delay/-/delay-4.2.0.tgz",
+			"integrity": "sha512-EBX+pZE4qSowGAMr6M0cLiPRQu2Kus/qTNLO7c+EoXpTPJH9ApFdHX+cQU1WsSHXgwhLyidfZ5Hxuq6ctWhSdw==",
+			"dev": true
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -3335,21 +3272,13 @@
 			}
 		},
 		"dom-serializer": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "~1.1.1",
-				"entities": "~1.1.1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-					"dev": true
-				}
+				"domelementtype": "^1.3.0",
+				"entities": "^1.1.1"
 			}
 		},
 		"domelementtype": {
@@ -3424,44 +3353,9 @@
 		},
 		"duplexer": {
 			"version": "0.1.1",
-			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
-		},
-		"duplexer2": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~1.1.9"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
 		},
 		"duplexer3": {
 			"version": "0.1.4",
@@ -3471,9 +3365,9 @@
 			"optional": true
 		},
 		"duplexify": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
@@ -3527,9 +3421,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.124",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz",
-			"integrity": "sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==",
+			"version": "1.3.125",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
+			"integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -3660,16 +3554,17 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
+				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
 			}
 		},
 		"es-to-primitive": {
@@ -3684,14 +3579,14 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.46",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-			"integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+			"version": "0.10.49",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
+			"integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
 			"dev": true,
 			"requires": {
 				"es6-iterator": "~2.0.3",
 				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
+				"next-tick": "^1.0.0"
 			}
 		},
 		"es6-iterator": {
@@ -3775,7 +3670,7 @@
 		},
 		"event-stream": {
 			"version": "3.3.4",
-			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
 			"dev": true,
 			"requires": {
@@ -4049,9 +3944,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
-			"integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+			"integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
 			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -4121,9 +4016,9 @@
 			}
 		},
 		"file-type": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-			"integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
+			"version": "10.11.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+			"integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==",
 			"dev": true
 		},
 		"filename-reserved-regex": {
@@ -4212,7 +4107,7 @@
 		},
 		"find-versions": {
 			"version": "1.2.1",
-			"resolved": "http://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
 			"integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
 			"dev": true,
 			"requires": {
@@ -4294,17 +4189,6 @@
 				"flatted": "^2.0.0",
 				"rimraf": "2.6.3",
 				"write": "1.0.3"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"flatted": {
@@ -4320,13 +4204,13 @@
 			"dev": true
 		},
 		"flush-write-stream": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.3.6"
 			}
 		},
 		"follow-redirects": {
@@ -4354,6 +4238,15 @@
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
+		},
+		"for-own": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+			"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.1"
+			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -4445,14 +4338,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+			"integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "^2.12.1",
+				"node-pre-gyp": "^0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -4474,7 +4367,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -4500,7 +4393,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -4530,16 +4423,16 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -4588,7 +4481,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -4608,12 +4501,12 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -4678,17 +4571,17 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -4706,35 +4599,35 @@
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
+						"debug": "^4.1.0",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.12.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -4751,13 +4644,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -4834,12 +4727,12 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -4869,16 +4762,16 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -4896,7 +4789,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.7.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -4949,17 +4842,17 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -4970,12 +4863,12 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -4985,7 +4878,7 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -5028,7 +4921,7 @@
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true,
 			"optional": true
@@ -5219,7 +5112,7 @@
 		},
 		"globby": {
 			"version": "6.1.0",
-			"resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"dev": true,
 			"requires": {
@@ -5403,7 +5296,7 @@
 			"dependencies": {
 				"opn": {
 					"version": "1.0.2",
-					"resolved": "http://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
 					"integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18=",
 					"dev": true
 				}
@@ -5480,7 +5373,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -5502,7 +5395,7 @@
 				},
 				"kind-of": {
 					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
 					"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
 					"dev": true
 				},
@@ -5619,94 +5512,6 @@
 				"through2": "^2.0.0",
 				"uglify-js": "^3.0.5",
 				"vinyl-sourcemaps-apply": "^0.2.0"
-			}
-		},
-		"gulp-util": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-			"dev": true,
-			"requires": {
-				"array-differ": "^1.0.0",
-				"array-uniq": "^1.0.2",
-				"beeper": "^1.0.0",
-				"chalk": "^1.0.0",
-				"dateformat": "^2.0.0",
-				"fancy-log": "^1.1.0",
-				"gulplog": "^1.0.0",
-				"has-gulplog": "^0.1.0",
-				"lodash._reescape": "^3.0.0",
-				"lodash._reevaluate": "^3.0.0",
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.template": "^3.0.0",
-				"minimist": "^1.1.0",
-				"multipipe": "^0.1.2",
-				"object-assign": "^3.0.0",
-				"replace-ext": "0.0.1",
-				"through2": "^2.0.0",
-				"vinyl": "^0.5.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
-				},
-				"clone-stats": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-					"dev": true
-				},
-				"object-assign": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-					"dev": true
-				},
-				"replace-ext": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "0.5.3",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-					"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-					"dev": true,
-					"requires": {
-						"clone": "^1.0.0",
-						"clone-stats": "^0.0.1",
-						"replace-ext": "0.0.1"
-					}
-				}
 			}
 		},
 		"gulp-vinyl-zip": {
@@ -5983,9 +5788,9 @@
 			}
 		},
 		"ieee754": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
 			"dev": true,
 			"optional": true
 		},
@@ -5996,38 +5801,46 @@
 			"dev": true
 		},
 		"imagemin": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/imagemin/-/imagemin-6.0.0.tgz",
-			"integrity": "sha512-m4Mxwt2QvCp1F85HXoTungXk0Y6XzuvQGqrK9qEddQfo/7x4aZjRENmyXXfc29ei4Mk55rW002bORG86YM3/aQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/imagemin/-/imagemin-6.1.0.tgz",
+			"integrity": "sha512-8ryJBL1CN5uSHpiBMX0rJw79C9F9aJqMnjGnrd/1CafegpNuA81RBAAru/jQQEOWlOJJlpRnlcVFF6wq+Ist0A==",
 			"dev": true,
 			"requires": {
-				"file-type": "^8.1.0",
+				"file-type": "^10.7.0",
 				"globby": "^8.0.1",
 				"make-dir": "^1.0.0",
 				"p-pipe": "^1.1.0",
-				"pify": "^3.0.0",
+				"pify": "^4.0.1",
 				"replace-ext": "^1.0.0"
 			},
 			"dependencies": {
 				"globby": {
-					"version": "8.0.1",
-					"resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+					"integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
 					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
+						"dir-glob": "2.0.0",
 						"fast-glob": "^2.0.2",
 						"glob": "^7.1.2",
 						"ignore": "^3.3.5",
 						"pify": "^3.0.0",
 						"slash": "^1.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+							"dev": true
+						}
 					}
 				},
 				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
 				}
 			}
@@ -6176,7 +5989,7 @@
 		},
 		"into-stream": {
 			"version": "3.1.0",
-			"resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
 			"dev": true,
 			"optional": true,
@@ -6207,9 +6020,9 @@
 			"dev": true
 		},
 		"is": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-			"integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+			"integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
 			"dev": true
 		},
 		"is-absolute": {
@@ -6290,15 +6103,6 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
-		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
-			"requires": {
-				"builtin-modules": "^1.0.0"
-			}
 		},
 		"is-callable": {
 			"version": "1.1.4",
@@ -6415,21 +6219,12 @@
 			"optional": true,
 			"requires": {
 				"file-type": "^10.4.0"
-			},
-			"dependencies": {
-				"file-type": {
-					"version": "10.6.0",
-					"resolved": "https://registry.npmjs.org/file-type/-/file-type-10.6.0.tgz",
-					"integrity": "sha512-GNOg09GC+rZzxetGZFoL7QOnWXRqvWuEdKURIJlr0d6MW107Iwy6voG1PPOrm5meG6ls59WkBmBMAZdVSVajRQ==",
-					"dev": true,
-					"optional": true
-				}
 			}
 		},
 		"is-glob": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
@@ -6504,27 +6299,27 @@
 			"optional": true
 		},
 		"is-path-cwd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.0.0.tgz",
-			"integrity": "sha512-m5dHHzpOXEiv18JEORttBO64UgTEypx99vCxQLjbBvGhOJxnTNglYoFXxwo6AbsQb79sqqycQEHv2hWkHZAijA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.1.0.tgz",
+			"integrity": "sha512-Sc5j3/YnM8tDeyCsVeKlm/0p95075DyLmDEIkSgQ7mXkrOX+uTCtmQFm0CYzVyJwcCCmO3k8qfJt17SxQwB5Zw==",
 			"dev": true
 		},
 		"is-path-in-cwd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.0.0.tgz",
-			"integrity": "sha512-6Vz5Gc9s/sDA3JBVu0FzWufm8xaBsqy1zn8Q6gmvGP6nSDMw78aS4poBNeatWjaRpTpxxLn1WOndAiOlk+qY8A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "^2.1.0"
 			}
 		},
 		"is-path-inside": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "^1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -6752,9 +6547,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -6798,14 +6593,11 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
-		"json-stable-stringify": {
+		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -6830,12 +6622,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -6944,7 +6730,7 @@
 		},
 		"load-json-file": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
@@ -7029,58 +6815,10 @@
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
 			"dev": true
 		},
-		"lodash._basecopy": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-			"dev": true
-		},
-		"lodash._basetostring": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-			"dev": true
-		},
-		"lodash._basevalues": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-			"dev": true
-		},
-		"lodash._getnative": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-			"dev": true
-		},
-		"lodash._isiterateecall": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-			"dev": true
-		},
-		"lodash._reescape": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-			"dev": true
-		},
-		"lodash._reevaluate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-			"dev": true
-		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
-		},
-		"lodash._root": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
 			"dev": true
 		},
 		"lodash.debounce": {
@@ -7089,43 +6827,11 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
-		"lodash.escape": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-			"dev": true,
-			"requires": {
-				"lodash._root": "^3.0.0"
-			}
-		},
-		"lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-			"dev": true
-		},
-		"lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-			"dev": true
-		},
 		"lodash.isfinite": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
 			"integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
 			"dev": true
-		},
-		"lodash.keys": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"dev": true,
-			"requires": {
-				"lodash._getnative": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
-			}
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -7133,37 +6839,23 @@
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
-		"lodash.restparam": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-			"dev": true
-		},
 		"lodash.template": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
 			"dev": true,
 			"requires": {
-				"lodash._basecopy": "^3.0.0",
-				"lodash._basetostring": "^3.0.0",
-				"lodash._basevalues": "^3.0.0",
-				"lodash._isiterateecall": "^3.0.0",
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.escape": "^3.0.0",
-				"lodash.keys": "^3.0.0",
-				"lodash.restparam": "^3.0.0",
-				"lodash.templatesettings": "^3.0.0"
+				"lodash._reinterpolate": "~3.0.0",
+				"lodash.templatesettings": "^4.0.0"
 			}
 		},
 		"lodash.templatesettings": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
 			"dev": true,
 			"requires": {
-				"lodash._reinterpolate": "^3.0.0",
-				"lodash.escape": "^3.0.0"
+				"lodash._reinterpolate": "~3.0.0"
 			}
 		},
 		"lodash.throttle": {
@@ -7325,7 +7017,7 @@
 		},
 		"map-stream": {
 			"version": "0.1.0",
-			"resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
 			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
 			"dev": true
 		},
@@ -7455,7 +7147,7 @@
 		},
 		"meow": {
 			"version": "3.7.0",
-			"resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
@@ -7511,12 +7203,6 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
-				"picomatch": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.5.tgz",
-					"integrity": "sha512-Zisqgaq/4P05ZclrU/g5XrzFqVo7YiJx+EP4haeVI9S7kvtZmZgmQMZfcvjEus9JcMhqZfQZObimT5ZydvKJGA==",
-					"dev": true
-				},
 				"to-regex-range": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7535,18 +7221,18 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "1.40.0"
 			}
 		},
 		"mimic-response": {
@@ -7567,7 +7253,7 @@
 		},
 		"minimist": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
@@ -7610,7 +7296,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
@@ -7619,7 +7305,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				}
@@ -7631,15 +7317,6 @@
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 			"dev": true
 		},
-		"multipipe": {
-			"version": "0.1.2",
-			"resolved": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-			"dev": true,
-			"requires": {
-				"duplexer2": "0.0.2"
-			}
-		},
 		"mute-stdout": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
@@ -7647,9 +7324,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
 			"dev": true,
 			"optional": true
 		},
@@ -7680,7 +7357,7 @@
 		},
 		"next-tick": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
 			"dev": true
 		},
@@ -7692,9 +7369,9 @@
 			"optional": true
 		},
 		"node-releases": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.15.tgz",
-			"integrity": "sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.16.tgz",
+			"integrity": "sha512-BOMWCW9CaT4sffMa5S9Mj4vYObvVShyo6JoM9WzzQOKVyNUn1+OVMUaQT3fo2tJKCMwHjqaDW/Pf3/JsYmPD2g==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -7711,25 +7388,22 @@
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
+				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"normalize-range": {
 			"version": "0.1.2",
@@ -7756,9 +7430,9 @@
 			"dev": true
 		},
 		"now-and-later": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
-			"integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+			"integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
 			"dev": true,
 			"requires": {
 				"once": "^1.3.2"
@@ -7796,7 +7470,7 @@
 		},
 		"nprogress": {
 			"version": "0.2.0",
-			"resolved": "http://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
 			"integrity": "sha1-y480xTIT2JVyP8urkH6UIq28r7E=",
 			"dev": true
 		},
@@ -7871,9 +7545,9 @@
 			}
 		},
 		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"dev": true
 		},
 		"object-path": {
@@ -7913,17 +7587,6 @@
 				"array-slice": "^1.0.0",
 				"for-own": "^1.0.0",
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"for-own": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -7944,17 +7607,6 @@
 			"requires": {
 				"for-own": "^1.0.0",
 				"make-iterator": "^1.0.0"
-			},
-			"dependencies": {
-				"for-own": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				}
 			}
 		},
 		"object.pick": {
@@ -7974,29 +7626,18 @@
 			"requires": {
 				"for-own": "^1.0.0",
 				"make-iterator": "^1.0.0"
-			},
-			"dependencies": {
-				"for-own": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true,
-					"requires": {
-						"for-in": "^1.0.1"
-					}
-				}
 			}
 		},
 		"object.values": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+			"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.6.1",
-				"function-bind": "^1.1.0",
-				"has": "^1.0.1"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.12.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
 			}
 		},
 		"on-finished": {
@@ -8065,7 +7706,7 @@
 		},
 		"os-locale": {
 			"version": "1.4.0",
-			"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"dev": true,
 			"requires": {
@@ -8109,7 +7750,7 @@
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
 			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
 			"dev": true,
 			"optional": true
@@ -8133,9 +7774,9 @@
 			}
 		},
 		"p-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
-			"integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
 			"dev": true
 		},
 		"p-map-series": {
@@ -8212,9 +7853,9 @@
 			}
 		},
 		"parse-node-version": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.0.tgz",
-			"integrity": "sha512-02GTVHD1u0nWc20n2G7WX/PgdhNFG04j5fi1OkaJzPWLTcf6vh6229Lta1wTmXG/7Dg42tCssgkccVt7qvd8Kg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
 			"dev": true
 		},
 		"parse-passwd": {
@@ -8270,7 +7911,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
@@ -8321,7 +7962,7 @@
 		},
 		"pause-stream": {
 			"version": "0.0.11",
-			"resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
 			"dev": true,
 			"requires": {
@@ -8341,14 +7982,14 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.4.tgz",
-			"integrity": "sha512-lN1llt2d+xBz96Vp+yj0qMUVMyDsqvNSecdRDIEuh72kQi1N6ttkxPJ7zDVwKR4ehD2R3WhMKqdp/5LeRfc+PA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.5.tgz",
+			"integrity": "sha512-Zisqgaq/4P05ZclrU/g5XrzFqVo7YiJx+EP4haeVI9S7kvtZmZgmQMZfcvjEus9JcMhqZfQZObimT5ZydvKJGA==",
 			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
-			"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 			"dev": true
 		},
@@ -8380,9 +8021,9 @@
 			}
 		},
 		"plur": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-3.0.1.tgz",
-			"integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
+			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
 			"dev": true,
 			"requires": {
 				"irregular-plurals": "^2.0.0"
@@ -8405,14 +8046,14 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-			"integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+			"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
+				"chalk": "^2.4.2",
 				"source-map": "^0.6.1",
-				"supports-color": "^5.5.0"
+				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -8420,6 +8061,15 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -8431,19 +8081,6 @@
 			"requires": {
 				"postcss": "^7.0.2",
 				"postcss-selector-parser": "^5.0.0"
-			},
-			"dependencies": {
-				"postcss-selector-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
-					"dev": true,
-					"requires": {
-						"cssesc": "^2.0.0",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				}
 			}
 		},
 		"postcss-calc": {
@@ -8480,13 +8117,13 @@
 			}
 		},
 		"postcss-color-hex-alpha": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.2.tgz",
-			"integrity": "sha512-8bIOzQMGdZVifoBQUJdw+yIY00omBd2EwkJXepQo9cjp1UOHHHoeRDeSzTP6vakEpaRc6GAIOfvcQR7jBYaG5Q==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
+			"integrity": "sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.2",
-				"postcss-values-parser": "^2.0.0"
+				"postcss": "^7.0.14",
+				"postcss-values-parser": "^2.0.1"
 			}
 		},
 		"postcss-color-mod-function": {
@@ -8534,22 +8171,22 @@
 			}
 		},
 		"postcss-custom-media": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.7.tgz",
-			"integrity": "sha512-bWPCdZKdH60wKOTG4HKEgxWnZVjAIVNOJDvi3lkuTa90xo/K0YHa2ZnlKLC5e2qF8qCcMQXt0yzQITBp8d0OFA==",
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
+			"integrity": "sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.5"
+				"postcss": "^7.0.14"
 			}
 		},
 		"postcss-custom-properties": {
-			"version": "8.0.9",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.9.tgz",
-			"integrity": "sha512-/Lbn5GP2JkKhgUO2elMs4NnbUJcvHX4AaF5nuJDaNkd2chYW1KA5qtOGGgdkBEWcXtKSQfHXzT7C6grEVyb13w==",
+			"version": "8.0.10",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.10.tgz",
+			"integrity": "sha512-GDL0dyd7++goDR4SSasYdRNNvp4Gqy1XMzcCnTijiph7VB27XXpJ8bW/AI0i2VSBZ55TpdGhMr37kMSpRfYD0Q==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.5",
-				"postcss-values-parser": "^2.0.0"
+				"postcss": "^7.0.14",
+				"postcss-values-parser": "^2.0.1"
 			}
 		},
 		"postcss-custom-selectors": {
@@ -8764,37 +8401,16 @@
 			"requires": {
 				"lodash.template": "^4.2.4",
 				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"lodash.template": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-					"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-					"dev": true,
-					"requires": {
-						"lodash._reinterpolate": "~3.0.0",
-						"lodash.templatesettings": "^4.0.0"
-					}
-				},
-				"lodash.templatesettings": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-					"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-					"dev": true,
-					"requires": {
-						"lodash._reinterpolate": "~3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.0.tgz",
-			"integrity": "sha512-9kAApW9G5kN8FkQ0ZdvSmbgbHIRrKmXtde2ZWYbwrW51gfEWfGsLlUu57mTpioPrmQlQFOgEvaeGYp+poqlX0A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.1.tgz",
+			"integrity": "sha512-8XQGohCbj6+kq8e3w6WlexkGaSjb5S8zoXnH49eB8JC6+qN2kQW+ib6fTjRgCpRRN9eeFOhMlD0NDjThW1DCBg==",
 			"dev": true,
 			"requires": {
-				"camelcase-css": "^2.0.0",
-				"postcss": "^7.0.0"
+				"camelcase-css": "^2.0.1",
+				"postcss": "^7.0.14"
 			}
 		},
 		"postcss-jsx": {
@@ -8824,56 +8440,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.14"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-load-config": {
@@ -9058,13 +8624,13 @@
 			},
 			"dependencies": {
 				"globby": {
-					"version": "8.0.1",
-					"resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+					"integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
 					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
+						"dir-glob": "2.0.0",
 						"fast-glob": "^2.0.2",
 						"glob": "^7.1.2",
 						"ignore": "^3.3.5",
@@ -9270,76 +8836,6 @@
 				"postcss-replace-overflow-wrap": "^3.0.0",
 				"postcss-selector-matches": "^4.0.0",
 				"postcss-selector-not": "^4.0.0"
-			},
-			"dependencies": {
-				"autoprefixer": {
-					"version": "9.4.10",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.10.tgz",
-					"integrity": "sha512-XR8XZ09tUrrSzgSlys4+hy5r2/z4Jp7Ag3pHm31U4g/CTccYPOVe19AkaJ4ey/vRd1sfj+5TtuD6I0PXtutjvQ==",
-					"dev": true,
-					"requires": {
-						"browserslist": "^4.4.2",
-						"caniuse-lite": "^1.0.30000940",
-						"normalize-range": "^0.1.2",
-						"num2fraction": "^1.2.2",
-						"postcss": "^7.0.14",
-						"postcss-value-parser": "^3.3.1"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000942",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000942.tgz",
-					"integrity": "sha512-wLf+IhZUy2rfz48tc40OH7jHjXjnvDFEYqBHluINs/6MgzoNLPf25zhE4NOVzqxLKndf+hau81sAW0RcGHIaBQ==",
-					"dev": true
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-pseudo-class-any-link": {
@@ -9395,58 +8891,6 @@
 				"lodash": "^4.17.11",
 				"log-symbols": "^2.2.0",
 				"postcss": "^7.0.7"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "2.4.2",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							},
-							"dependencies": {
-								"supports-color": {
-									"version": "5.5.0",
-									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-									"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-									"dev": true,
-									"requires": {
-										"has-flag": "^3.0.0"
-									}
-								}
-							}
-						}
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-resolve-nested-selector": {
@@ -9504,9 +8948,9 @@
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "5.0.0-rc.4",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0-rc.4.tgz",
-			"integrity": "sha512-0XvfYuShrKlTk1ooUrVzMCFQRcypsdEIsGqh5IxC5rdtBi4/M/tDAJeSONwC2MTqEFsmPZYAV7Dd4X8rgAfV0A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+			"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 			"dev": true,
 			"requires": {
 				"cssesc": "^2.0.0",
@@ -9515,12 +8959,12 @@
 			}
 		},
 		"postcss-simple-vars": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-simple-vars/-/postcss-simple-vars-5.0.1.tgz",
-			"integrity": "sha512-nlulz+X0i8CH2e9IbxFfMD9rG4fGx+O4hH7Pwj0bZalRx91gvli85DAymqBQ35X7VBUackGD2iNj7DgsCbwQug==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-simple-vars/-/postcss-simple-vars-5.0.2.tgz",
+			"integrity": "sha512-xWIufxBoINJv6JiLb7jl5oElgp+6puJwvT5zZHliUSydoLz4DADRB3NDDsYgfKVwojn4TDLiseoC65MuS8oGGg==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.2"
+				"postcss": "^7.0.14"
 			}
 		},
 		"postcss-svgo": {
@@ -9584,7 +9028,7 @@
 		},
 		"pretty-hrtime": {
 			"version": "1.0.3",
-			"resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
 			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
 			"dev": true
 		},
@@ -9661,7 +9105,7 @@
 		},
 		"query-string": {
 			"version": "5.1.1",
-			"resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
 			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 			"dev": true,
 			"optional": true,
@@ -9736,7 +9180,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
@@ -10069,12 +9513,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-dir": {
@@ -10164,13 +9608,12 @@
 			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "^7.1.3"
 			}
 		},
 		"rx": {
@@ -10196,7 +9639,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
@@ -10227,7 +9670,7 @@
 			"dependencies": {
 				"commander": {
 					"version": "2.8.1",
-					"resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
 					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
 					"dev": true,
 					"optional": true,
@@ -10238,9 +9681,9 @@
 			}
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 			"dev": true
 		},
 		"semver-greatest-satisfied-range": {
@@ -10870,9 +10313,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-			"integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
 			"dev": true
 		},
 		"specificity": {
@@ -10883,7 +10326,7 @@
 		},
 		"split": {
 			"version": "0.3.3",
-			"resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
 			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
 			"dev": true,
 			"requires": {
@@ -10901,7 +10344,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
@@ -10926,7 +10369,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"optional": true,
@@ -10948,9 +10391,9 @@
 			}
 		},
 		"sshpk": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -11011,7 +10454,7 @@
 		},
 		"stream-combiner": {
 			"version": "0.0.4",
-			"resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
 			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
 			"dev": true,
 			"requires": {
@@ -11060,7 +10503,7 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
@@ -11081,7 +10524,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
@@ -11115,7 +10558,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true,
 			"optional": true
@@ -11247,29 +10690,6 @@
 						"quick-lru": "^1.0.0"
 					}
 				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"cosmiconfig": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
-					"integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
-					"dev": true,
-					"requires": {
-						"import-fresh": "^2.0.0",
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.13.0",
-						"parse-json": "^4.0.0"
-					}
-				},
 				"dir-glob": {
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
@@ -11277,52 +10697,6 @@
 					"dev": true,
 					"requires": {
 						"path-type": "^3.0.0"
-					}
-				},
-				"fast-glob": {
-					"version": "2.2.6",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
-					"integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
-					"dev": true,
-					"requires": {
-						"@mrmlnc/readdir-enhanced": "^2.2.1",
-						"@nodelib/fs.stat": "^1.1.2",
-						"glob-parent": "^3.1.0",
-						"is-glob": "^4.0.0",
-						"merge2": "^1.2.3",
-						"micromatch": "^3.1.10"
-					},
-					"dependencies": {
-						"micromatch": {
-							"version": "3.1.10",
-							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-							"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-							"dev": true,
-							"requires": {
-								"arr-diff": "^4.0.0",
-								"array-unique": "^0.3.2",
-								"braces": "^2.3.1",
-								"define-property": "^2.0.2",
-								"extend-shallow": "^3.0.2",
-								"extglob": "^2.0.4",
-								"fragment-cache": "^0.2.1",
-								"kind-of": "^6.0.2",
-								"nanomatch": "^1.2.9",
-								"object.pick": "^1.3.0",
-								"regex-not": "^1.0.0",
-								"snapdragon": "^0.8.1",
-								"to-regex": "^3.0.2"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
 					}
 				},
 				"find-up": {
@@ -11402,22 +10776,6 @@
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -11461,27 +10819,6 @@
 						"yargs-parser": "^10.0.0"
 					}
 				},
-				"micromatch": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.1.tgz",
-					"integrity": "sha512-6yawNHAc4S9Dh81xZCkZ5sXKH0/ly0t1DiOc+rnqzi0OvwS4DgRZU+HYTNDIgULgZXTNw5N8Vhxh2va8nEO6BA==",
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.3"
-					},
-					"dependencies": {
-						"braces": {
-							"version": "3.0.2",
-							"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-							"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-							"dev": true,
-							"requires": {
-								"fill-range": "^7.0.1"
-							}
-						}
-					}
-				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -11514,28 +10851,6 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "6.1.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-							"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
 				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
@@ -11591,12 +10906,6 @@
 					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 					"dev": true
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
 				"string-width": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
@@ -11628,15 +10937,6 @@
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
 					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
 					"dev": true
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
@@ -11705,23 +11005,23 @@
 			"dev": true
 		},
 		"svgo": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
-			"integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
+			"integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
 			"dev": true,
 			"requires": {
-				"coa": "~2.0.1",
-				"colors": "~1.1.2",
+				"chalk": "^2.4.1",
+				"coa": "^2.0.2",
 				"css-select": "^2.0.0",
-				"css-select-base-adapter": "~0.1.0",
+				"css-select-base-adapter": "^0.1.1",
 				"css-tree": "1.0.0-alpha.28",
 				"css-url-regex": "^1.1.0",
-				"csso": "^3.5.0",
-				"js-yaml": "^3.12.0",
+				"csso": "^3.5.1",
+				"js-yaml": "^3.13.1",
 				"mkdirp": "~0.5.1",
-				"object.values": "^1.0.4",
+				"object.values": "^1.1.0",
 				"sax": "~1.2.4",
-				"stable": "~0.1.6",
+				"stable": "^0.1.8",
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
 			}
@@ -11744,18 +11044,6 @@
 				"string-width": "^3.0.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.10.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -11869,7 +11157,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
@@ -11893,9 +11181,9 @@
 			}
 		},
 		"through2-filter": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+			"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
 			"dev": true,
 			"requires": {
 				"through2": "~2.0.0",
@@ -12103,21 +11391,15 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.6.tgz",
+			"integrity": "sha512-YDKRX8F0Y+Jr7LhoVk0n4G7ltR3Y7qFAj+DtVBthlOgCcIj1hyMigCfousVfn9HKmvJ+qiFlLDwaHx44/e5ZKw==",
 			"dev": true,
 			"requires": {
-				"commander": "~2.17.1",
+				"commander": "~2.20.0",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.17.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-					"dev": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12133,14 +11415,14 @@
 			"dev": true
 		},
 		"unbzip2-stream": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
-			"integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+			"integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"buffer": "^3.0.1",
-				"through": "^2.3.6"
+				"buffer": "^5.2.1",
+				"through": "^2.3.8"
 			}
 		},
 		"unc-path-regex": {
@@ -12274,13 +11556,13 @@
 			"dev": true
 		},
 		"unique-stream": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
 			"dev": true,
 			"requires": {
-				"json-stable-stringify": "^1.0.0",
-				"through2-filter": "^2.0.0"
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"through2-filter": "^3.0.0"
 			}
 		},
 		"unist-util-find-all-after": {
@@ -12396,9 +11678,9 @@
 			}
 		},
 		"upath": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
 			"dev": true
 		},
 		"uri-js": {
@@ -12596,6 +11878,17 @@
 				"now-and-later": "^2.0.0",
 				"remove-bom-buffer": "^3.0.0",
 				"vinyl": "^2.0.0"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				}
 			}
 		},
 		"vinyl-sourcemaps-apply": {
@@ -12630,7 +11923,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,14 @@
 		"@babel/core": "^7.4.3",
 		"@babel/preset-env": "^7.4.3",
 		"aos": "^2.3.4",
+		"beeper": "^2.0.0",
 		"browser-sync": "^2.26.4",
 		"browserslist": "^4.5.5",
 		"cssnano": "^4.1.10",
 		"del": "^4.1.0",
+		"fancy-log": "^1.3.3",
 		"fs": "0.0.2",
+		"gulp": "^4.0.1",
 		"gulp-babel": "^8.0.0",
 		"gulp-concat": "^2.6.1",
 		"gulp-connect-php": "^1.0.3",
@@ -32,9 +35,7 @@
 		"gulp-remote-src": "^0.4.4",
 		"gulp-sourcemaps": "^2.6.5",
 		"gulp-uglify": "^3.0.2",
-		"gulp-util": "^3.0.8",
 		"gulp-vinyl-zip": "^2.1.2",
-		"gulp": "^4.0.1",
 		"isotope-layout": "^3.0.6",
 		"jquery": "^3.4.0",
 		"normalize.css": "^8.0.1",
@@ -42,7 +43,8 @@
 		"postcss-easy-import": "^3.0.0",
 		"postcss-mixins": "^6.2.1",
 		"postcss-preset-env": "^6.6.0",
-		"stylelint-config-standard": "^18.3.0",
-		"stylelint": "^10.0.1"
-	}
+		"stylelint": "^10.0.1",
+		"stylelint-config-standard": "^18.3.0"
+	},
+	"dependencies": {}
 }


### PR DESCRIPTION
As gulp-util is deprecated, I've replaced the beeper and log functionality with individual packages recommended in the guidelines at https://www.npmjs.com/package/gulp-util