### PR TITLE
removed fs package. This package is not necessary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1467,8 +1467,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
 			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"base64id": {
 			"version": "1.0.0",
@@ -1767,7 +1766,6 @@
 					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
 					"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"p-finally": "^1.0.0"
 					}
@@ -1827,7 +1825,6 @@
 			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
 			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
@@ -2007,7 +2004,6 @@
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
 			"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4"
@@ -2018,7 +2014,6 @@
 			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
 			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"buffer-alloc-unsafe": "^1.1.0",
 				"buffer-fill": "^1.0.0"
@@ -2028,8 +2023,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
 			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
@@ -2047,8 +2041,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
 			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -2228,7 +2221,6 @@
 			"resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
 			"integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"get-proxy": "^2.0.0",
 				"isurl": "^1.0.0-alpha5",
@@ -2544,7 +2536,6 @@
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
 			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
@@ -2597,7 +2588,6 @@
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
 			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"safe-buffer": "5.1.2"
 			}
@@ -2693,7 +2683,6 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -3005,7 +2994,6 @@
 			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
 			"integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"decompress-tar": "^4.0.0",
 				"decompress-tarbz2": "^4.0.0",
@@ -3022,7 +3010,6 @@
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -3032,7 +3019,6 @@
 			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
 			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"file-type": "^5.2.0",
 				"is-stream": "^1.1.0",
@@ -3043,8 +3029,7 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
 					"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -3053,7 +3038,6 @@
 			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
 			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"decompress-tar": "^4.1.0",
 				"file-type": "^6.1.0",
@@ -3066,8 +3050,7 @@
 					"version": "6.2.0",
 					"resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
 					"integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -3076,7 +3059,6 @@
 			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
 			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"decompress-tar": "^4.1.1",
 				"file-type": "^5.2.0",
@@ -3087,8 +3069,7 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
 					"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -3097,7 +3078,6 @@
 			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
 			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"file-type": "^3.8.0",
 				"get-stream": "^2.2.0",
@@ -3109,15 +3089,13 @@
 					"version": "3.9.0",
 					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
 					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"get-stream": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
 					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"object-assign": "^4.0.1",
 						"pinkie-promise": "^2.0.0"
@@ -3386,8 +3364,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"duplexify": {
 			"version": "3.7.1",
@@ -3742,7 +3719,6 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -3836,7 +3812,6 @@
 			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
 			"integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"mime-db": "^1.28.0"
 			}
@@ -3846,7 +3821,6 @@
 			"resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
 			"integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"ext-list": "^2.0.0",
 				"sort-keys-length": "^1.0.0"
@@ -4050,15 +4024,13 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
 			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"filenamify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
 			"integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"filename-reserved-regex": "^2.0.0",
 				"strip-outer": "^1.0.0",
@@ -4322,18 +4294,11 @@
 				"readable-stream": "^2.0.0"
 			}
 		},
-		"fs": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/fs/-/fs-0.0.2.tgz",
-			"integrity": "sha1-4fJE7zkzwbKmS9R5kTYGDQ9ZFPg=",
-			"dev": true
-		},
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"fs-extra": {
 			"version": "3.0.1",
@@ -4382,8 +4347,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4404,14 +4368,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4426,20 +4388,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4556,8 +4515,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4569,7 +4527,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4584,7 +4541,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4592,14 +4548,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4618,7 +4572,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4699,8 +4652,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4712,7 +4664,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4798,8 +4749,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4835,7 +4785,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4855,7 +4804,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4899,14 +4847,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -4927,7 +4873,6 @@
 			"resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
 			"integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"npm-conf": "^1.1.0"
 			}
@@ -4948,8 +4893,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -5213,8 +5157,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
 			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"gulp": {
 			"version": "4.0.2",
@@ -5631,8 +5574,7 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
 			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.0",
@@ -5645,7 +5587,6 @@
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"has-symbol-support-x": "^1.4.1"
 			}
@@ -5816,8 +5757,7 @@
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -6272,8 +6212,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
 			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"is-negated-glob": {
 			"version": "1.0.0",
@@ -6320,8 +6259,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
 			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"is-path-cwd": {
 			"version": "2.1.0",
@@ -6409,8 +6347,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
 			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -6535,7 +6472,6 @@
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"has-to-string-tag-x": "^1.2.0",
 				"is-object": "^1.0.1"
@@ -6951,8 +6887,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
 			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"lpad-align": {
 			"version": "1.1.2",
@@ -6972,7 +6907,6 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -7264,8 +7198,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
 			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -7390,8 +7323,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"node-releases": {
 			"version": "1.1.21",
@@ -7468,7 +7400,6 @@
 			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
 			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"config-chain": "^1.1.11",
 				"pify": "^3.0.0"
@@ -7478,8 +7409,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -7488,7 +7418,6 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -7770,8 +7699,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
@@ -7832,7 +7760,6 @@
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
 			"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
@@ -7950,8 +7877,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -9073,15 +8999,13 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"psl": {
 			"version": "1.1.31",
@@ -9688,7 +9612,6 @@
 			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
 			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"commander": "~2.8.1"
 			},
@@ -9698,7 +9621,6 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
 					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"graceful-readlink": ">= 1.0.0"
 					}
@@ -9911,7 +9833,6 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -9920,8 +9841,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -10265,7 +10185,6 @@
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -10275,7 +10194,6 @@
 			"resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
 			"integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"sort-keys": "^1.0.0"
 			}
@@ -10576,7 +10494,6 @@
 			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
 			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"is-natural-number": "^4.0.1"
 			}
@@ -10585,8 +10502,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"strip-indent": {
 			"version": "1.0.1",
@@ -10602,7 +10518,6 @@
 			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
 			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.2"
 			}
@@ -11114,7 +11029,6 @@
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
 			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"bl": "^1.0.0",
 				"buffer-alloc": "^1.2.0",
@@ -11129,15 +11043,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
 			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"tempfile": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
 			"integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"temp-dir": "^1.0.0",
 				"uuid": "^3.0.1"
@@ -11225,8 +11137,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"timers-ext": {
 			"version": "0.1.7",
@@ -11264,8 +11175,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
 			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
@@ -11365,7 +11275,6 @@
 			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
 			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.2"
 			}
@@ -11444,7 +11353,6 @@
 			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
 			"integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"buffer": "^5.2.1",
 				"through": "^2.3.8"
@@ -11737,8 +11645,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
 			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"use": {
 			"version": "3.1.1",
@@ -12008,8 +11915,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"yargs": {
 			"version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"cssnano": "^4.1.10",
 		"del": "^4.1.1",
 		"fancy-log": "^1.3.3",
-		"fs": "0.0.2",
+		"gulp": "^4.0.2",
 		"gulp-babel": "^8.0.0",
 		"gulp-concat": "^2.6.1",
 		"gulp-connect-php": "^1.0.3",
@@ -35,7 +35,6 @@
 		"gulp-sourcemaps": "^2.6.5",
 		"gulp-uglify": "^3.0.2",
 		"gulp-vinyl-zip": "^2.1.2",
-		"gulp": "^4.0.2",
 		"isotope-layout": "^3.0.6",
 		"jquery": "^3.4.1",
 		"normalize.css": "^8.0.1",
@@ -43,7 +42,7 @@
 		"postcss-easy-import": "^3.0.0",
 		"postcss-mixins": "^6.2.1",
 		"postcss-preset-env": "^6.6.0",
-		"stylelint-config-standard": "^18.3.0",
-		"stylelint": "^10.0.1"
+		"stylelint": "^10.0.1",
+		"stylelint-config-standard": "^18.3.0"
 	}
 }


### PR DESCRIPTION
removed fs package. This package is not necessary because it is part of the NodeJS.
the removed package refers [https://www.npmjs.com/package/fs](url), description:

> This package name is not currently in use, but was formerly occupied by another package. To avoid malicious use, npm is hanging on to the package name, but loosely, and we'll probably give it to you if you want it.

You may adopt this package by contacting support@npmjs.com and requesting the name.