### PR TITLE
Remove not used aos

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,7 @@ const pluginsListProd = [
 /* -------------------------------------------------------------------------------------------------
 Header & Footer JavaScript Boundles
 -------------------------------------------------------------------------------------------------- */
-const headerJS = ['./node_modules/jquery/dist/jquery.js', './node_modules/aos/dist/aos.js'];
+const headerJS = ['./node_modules/jquery/dist/jquery.js'];
 
 const footerJS = ['./src/assets/js/**'];
 


### PR DESCRIPTION
Not everyone is using this, so theres no need to have it by default. 