### PR TITLE
(fix) Update Readme to include missing function call in prod sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Change the gulp tasks styleProd to:
 ```javascript
 function stylesProd() {
 	return src('./src/assets/css/style.scss')
-		.pipe({includePaths: 'node_modules'}).on("error", sass.logError)
+		.pipe(sass({includePaths: 'node_modules'})).on("error", sass.logError)
 		.pipe(dest('./dist/themes/' + themeName));
 }
 ```


### PR DESCRIPTION
Invalid pipe call, needs the sass call passed to pipe.