### PR TITLE
Remove await before fs.existsSync()

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ async function unzipWordPress() {
 }
 
 async function copyConfig() {
-	if (await fs.existsSync('./wp-config.php')) {
+	if (fs.existsSync('./wp-config.php')) {
 		return src('./wp-config.php')
 			.pipe(inject.after("define( 'DB_COLLATE', '' );", "\ndefine( 'DISABLE_WP_CRON', true );"))
 			.pipe(dest('./build/wordpress'));


### PR DESCRIPTION
fs.existsSync() does not return a promise,
so there is no need to have await before it.