### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,17 @@
+name: "Install and Start WordPressify"
+
+env:
+  WPFY_GH_REPO: ${{ github.repository }}
+  WPFY_GH_REF: ${{ github.ref }}
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm ci --no-audit
+      - run: ./installer/index.js -y

--- a/installer/index.js
+++ b/installer/index.js
@@ -22,18 +22,22 @@ const version = require('../package.json').version;
 
 program
 	.version(version, '-v, --vers', 'output the current version')
+	.option('-y, --non-interactive', 'do not prompt for user input')
 	.parse(process.argv);
 
 (async () => {
-	const response = await prompts({
-		type: 'confirm',
-		name: 'value',
-		message: `Do you want to install ${chalk.white.bgGreen(
-			'🎈 WordPressify',
-		)} in the current directory?\n${chalk.red(process.cwd())}`,
-	});
+	let response = {};
+	if (!program.nonInteractive) {
+			response = await prompts({
+			type: 'confirm',
+			name: 'value',
+			message: `Do you want to install ${chalk.white.bgGreen(
+				'🎈 WordPressify',
+			)} in the current directory?\n${chalk.red(process.cwd())}`,
+		});
+	}
 
-	if (response.value) {
+	if (program.nonInteractive || response.value) {
 		// If below Node 8.
 		if (8 > major) {
 			console.error(

--- a/installer/modules/run.js
+++ b/installer/modules/run.js
@@ -18,6 +18,16 @@ module.exports = () => {
 	// Init.
 	clearConsole();
 
+	let upstreamUrl = '';
+	// When running GitHub actions, make sure the files from current repo are downloaded
+	if (process.env.WPFY_GH_REPO) {
+  	let refname = process.env.WPFY_GH_REF.split('/');
+    refname = refname[refname.length-1];
+		upstreamUrl = `https://raw.githubusercontent.com/${process.env.WPFY_GH_REPO}/${refname}`;
+	} else {
+		upstreamUrl = 'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18';
+	}
+
 	// Files.
 	const filesToDownload = [
 		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/.babelrc',


### PR DESCRIPTION
While I was working on changes it became a bit annoying to keep manually checking that I didn't break anything. So I added GitHub Actions continuous integration to make sure that new pushes don't break anything. Every time someone pushes something, it gets built and installed on a GitHub VM. 