### PR TITLE
Add database running in Docker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = tab
-indent_size = 2
+indent_size = 1
 
 [*.yml]
 indent_style = space

--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+DB_PORT=8805
+DB_NAME=wordpress
+DB_USER=root
+DB_PASSWORD=root

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ dist
 build
 tmp
 backups
-wp-config.php
 
 # IDE & Editors
 .idea

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ http://www.wordpressify.co/
 
 - [Introduction](#introduction)
 	- [Features](#features)
-- [1. Installing Node](#1-installing-node)
+- [1. Installing Node and Docker](#1-installing-node-and-docker)
 - [2. Set Up Project](#2-set-up-project)
 	- [Install WordPressify from NPM](#install-wordpressify-from-npm)
 	- [Install WordPressify from Repository](#install-wordpressify-from-repository)
@@ -24,12 +24,9 @@ http://www.wordpressify.co/
 - [7. Build Backups](#7-build-backups)
 - [8. Code Style Rules](#8-code-style-rules)
 	- [Lint CSS](#lint-css)
-- [9. Database](#9-database)
-	- [MySQL/MariaDB Server](#mysqlmariadb-server)
-	- [Remote Database](#remote-database)
-- [10. Deployment](#10-deployment)
+- [9. Deployment](#9-deployment)
 	- [Automated Deployments](#automated-deployments)
-- [11. Windows Installation](#11-windows-installation)
+- [10. Windows Installation](#10-windows-installation)
 - [Changelog](#changelog)
 - [License](#license)
 
@@ -55,10 +52,16 @@ http://www.wordpressify.co/
 
 WordPressify comes with a development server for PHP running under a proxy with BrowserSync. Watches for all your changes and reloads the webpage in real-time. Style are preprocessors with PostCSS or Sass. Babel compiler for writing next-generation JavaScript. Source maps are supported for both CSS and JavaScript. WordPressify allows easy import of external JavaScript libraries and npm scripts, it has a flexible build and can be easily customized with gulp tasks.
 
-# 1. Installing Node
-WordPressify requires Node v7.5+. This is the only global dependency. You can download Node **[here](https://nodejs.org/)**.
+# 1. Installing Node and Docker
+WordPressify requires Node v7.5+ and Docker Compose.
 
 Node.js is a JavaScript runtime built on Chrome’s V8 JavaScript engine. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient. Node.js’ package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
+
+You can download Node **[here](https://nodejs.org/)**.
+
+Instructions to download Docker Compose can be found **[here](https://docs.docker.com/compose/install)**.
+
+If you're on Linux **make sure that you can [manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/)**.
 
 # 2. Set Up Project
 ## File Structure
@@ -131,6 +134,13 @@ npm run install:wordpress
 
 - It will fetch the latest WordPress version, which is the build we use for the development server.
 
+**START DATABASE**
+
+- Bring up the MariaDB database:
+```
+docker-compose up -d
+```
+
 **START WORKFLOW**
 
 - We are ready to start our development server with the command:
@@ -161,7 +171,7 @@ dist/wordpressify.zip
 ```
 
 **WINDOWS USERS**
-- If you are running Windows, PHP has to be installed and configured. Check the [gulp-connect-php](https://www.npmjs.com/package/gulp-connect-php) documentation. 
+- If you are running Windows, PHP has to be installed and configured. Check the [gulp-connect-php](https://www.npmjs.com/package/gulp-connect-php) documentation.
 
 We prepared a video screencast **demonstrating the installation processs using a Windows** operating system, you can find it here: [How to install WordPressify on Windows?](https://www.wordpressify.co/windows-installation/)
 Or check out this tutorial on [Medium](https://medium.com/@marcus.supernova/how-to-install-wordpressify-on-windows-4b78a801165b).
@@ -359,14 +369,7 @@ Before pushing changes make sure you have clean and consistent CSS. Run [styleli
 npm run lint:css
 ```
 
-# 9. Database
-## MySQL/MariaDB Server
-After installing WordPressify you will still need a database to store WordPress content. The recommended solution is to install either [MySQL](https://dev.mysql.com/downloads/mysql/) ([installation instructions](https://dev.mysql.com/doc/refman/5.7/en/installing.html)) or [MariaDB](https://mariadb.com/downloads/mariadb-tx) ([installation instructions](https://mariadb.com/products/get-started)) on your local machine.
-
-## Remote Database
-You are free to use remote databases. Please note that this will affect the speed depending on the connection.
-
-# 10. Deployment
+# 9. Deployment
 The recommended solution is to go with [WP Pusher](https://wppusher.com/). It is easy and quick to deploy automatically from GitHub or other services. The first step is to download the WordPress plugin from: https://wppusher.com/
 
 Then navigate to your WordPress administration on your live site and install the downloaded plugin: Plugins -> Add New -> Upload Plugin -> Install Now.
@@ -378,7 +381,7 @@ At this point go to your terminal, navigate to your WordPressify project and gen
 npm run prod
 ```
 
-Navigate to your theme distribution files on: 
+Navigate to your theme distribution files on:
 ```
 dist/theme/<themeName>
 ```
@@ -391,11 +394,11 @@ On Repository host we choose GitHub, then click on **Pick from GitHub** and choo
 
 ## Automated Deployments
 **Push-to-Deploy** if you want automatic deployments to happen when you do a push to the distribution repository.
-In this case you have to create a Webhook from your GitHub's repository page. 
+In this case you have to create a Webhook from your GitHub's repository page.
 
-First navigate to the WP Pusher plugin page and click on **Themes**, it will show you the list of the templates you have installed through the plugin itself. Click on **Show Push-to-Deploy URL** to get the Payload URL. 
+First navigate to the WP Pusher plugin page and click on **Themes**, it will show you the list of the templates you have installed through the plugin itself. Click on **Show Push-to-Deploy URL** to get the Payload URL.
 
-Now get back to GitHub and navigate to your distribution repository and click on: Settings -> Webhooks -> Add webhook. Now past the URL and click **Add webhook**. 
+Now get back to GitHub and navigate to your distribution repository and click on: Settings -> Webhooks -> Add webhook. Now past the URL and click **Add webhook**.
 
 This should enable automatic deployment on any push to the chosen GitHub repository.
 
@@ -403,7 +406,7 @@ This should enable automatic deployment on any push to the chosen GitHub reposit
 
 This will **immediately** remove the default styles and leave a minimal viable theme with basic PHP WordPress loops and other useful features.
 
-# 11. Windows Installation
+# 10. Windows Installation
 **[How to install WordPressify on Windows?](https://www.youtube.com/watch?v=J8ZNzKSeTSE)**
 
 Assuming that you are using the latest version of Windows, and you have activated Windows Subsystem for Linux. Follow the instructions:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+services:
+  db:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
+      MYSQL_DATABASE: "${DB_NAME}"
+    ports:
+      - "${DB_PORT}:3306"
+    expose:
+      - "3306"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,9 @@ const remoteSrc = require('gulp-remote-src');
 const sourcemaps = require('gulp-sourcemaps');
 const uglify = require('gulp-uglify');
 const zip = require('gulp-vinyl-zip');
+const batchReplace = require('gulp-batch-replace');
+const dotenv = require('dotenv');
+const path = require('path');
 
 /* -------------------------------------------------------------------------------------------------
 Theme Name
@@ -88,7 +91,14 @@ async function unzipWordPress() {
 
 async function copyConfig() {
 	if (fs.existsSync('./wp-config.php')) {
+		const env = fs.readFileSync(path.join(__dirname, '.env'));
+		const data = dotenv.parse(env);
+		const replacements = []
+		for (const key of Object.keys(data)){
+				replacements.push([`{{${key}}}`, data[key]])
+			}
 		return src('./wp-config.php')
+			.pipe(batchReplace(replacements))
 			.pipe(inject.after("define( 'DB_COLLATE', '' );", "\ndefine( 'DISABLE_WP_CRON', true );"))
 			.pipe(dest('./build/wordpress'));
 	}

--- a/installer/modules/run.js
+++ b/installer/modules/run.js
@@ -30,43 +30,46 @@ module.exports = () => {
 
 	// Files.
 	const filesToDownload = [
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/.babelrc',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/.gitignore',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/.stylelintrc',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/LICENSE',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/README.md',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/gulpfile.js',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/installer/package.json',
+		`${upstreamUrl}/.babelrc`,
+		`${upstreamUrl}/.gitignore`,
+		`${upstreamUrl}/.stylelintrc`,
+		`${upstreamUrl}/.env`,
+		`${upstreamUrl}/LICENSE`,
+		`${upstreamUrl}/README.md`,
+		`${upstreamUrl}/gulpfile.js`,
+		`${upstreamUrl}/docker-compose.yml`,
+		`${upstreamUrl}/wp-config.php`,
+		`${upstreamUrl}/installer/package.json`,
 
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/assets/css/globals.css',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/assets/css/mixins.css',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/assets/css/style.css',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/assets/css/variables.css',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/assets/css/wordpressify.css',
+		`${upstreamUrl}/src/assets/css/globals.css`,
+		`${upstreamUrl}/src/assets/css/mixins.css`,
+		`${upstreamUrl}/src/assets/css/style.css`,
+		`${upstreamUrl}/src/assets/css/variables.css`,
+		`${upstreamUrl}/src/assets/css/wordpressify.css`,
 
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/assets/js/main.js',
+		`${upstreamUrl}/src/assets/js/main.js`,
 
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/404.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/archive.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/comments.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/content-none.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/content-page.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/content-single.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/content.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/footer.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/functions.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/header.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/index.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/page.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/screenshot.png',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/search.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/searchform.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/sidebar.php',
-		'https://raw.githubusercontent.com/luangjokaj/wordpressify/v0.2.8-18/src/theme/single.php',
+		`${upstreamUrl}/src/theme/404.php`,
+		`${upstreamUrl}/src/theme/archive.php`,
+		`${upstreamUrl}/src/theme/comments.php`,
+		`${upstreamUrl}/src/theme/content-none.php`,
+		`${upstreamUrl}/src/theme/content-page.php`,
+		`${upstreamUrl}/src/theme/content-single.php`,
+		`${upstreamUrl}/src/theme/content.php`,
+		`${upstreamUrl}/src/theme/footer.php`,
+		`${upstreamUrl}/src/theme/functions.php`,
+		`${upstreamUrl}/src/theme/header.php`,
+		`${upstreamUrl}/src/theme/index.php`,
+		`${upstreamUrl}/src/theme/page.php`,
+		`${upstreamUrl}/src/theme/screenshot.png`,
+		`${upstreamUrl}/src/theme/search.php`,
+		`${upstreamUrl}/src/theme/searchform.php`,
+		`${upstreamUrl}/src/theme/sidebar.php`,
+		`${upstreamUrl}/src/theme/single.php`,
 	];
 
 	// Organise file structure
-	const dotFiles = ['.babelrc', '.gitignore', '.stylelintrc'];
+	const dotFiles = ['.babelrc', '.gitignore', '.stylelintrc', '.env'];
 	const cssFiles = ['globals.css', 'mixins.css', 'style.css', 'variables.css', 'wordpressify.css'];
 	const jsFiles = ['main.js'];
 	const pluginFiles = ['README.md'];

--- a/installer/package.json
+++ b/installer/package.json
@@ -64,6 +64,8 @@
 		"postcss-easy-import": "^3.0.0",
 		"postcss-mixins": "^7.0.1",
 		"postcss-preset-env": "^6.7.0",
-		"stylelint": "^13.8.0"
+		"stylelint": "^13.8.0",
+		"gulp-batch-replace": "^0.0.0",
+		"dotenv": "^8.2.0"
 	}
 }

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to "wp-config.php" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://wordpress.org/support/article/editing-wp-config-php/
+ *
+ * @package WordPress
+ */
+
+/** The name of the database for WordPress */
+define( 'DB_NAME', '{{DB_NAME}}' );
+
+/** MySQL database username */
+define( 'DB_USER', '{{DB_USER}}' );
+
+/** MySQL database password */
+define( 'DB_PASSWORD', '{{DB_PASSWORD}}' );
+
+/** MySQL hostname */
+define( 'DB_HOST', '0.0.0.0:{{DB_PORT}}' );
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8mb4' );
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+define( 'FS_METHOD', 'direct');
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define( 'AUTH_KEY',         '#yo:M S<w![p_j!45pvr@R_jJRL@L hal.:V0zdYYCfiI(wLBWY.P0~MHZ8~FG#}' );
+define( 'SECURE_AUTH_KEY',  'Un4&pt^=I:vFO||)8<XI^rj/00%c0->um@(?m]]t;5=UP^M$41B9]<^s[QI>~i&p' );
+define( 'LOGGED_IN_KEY',    'o9E}sZ#o7wcVOc~gN/~JW~jWN7![|j->4|WCk(MS}Zj_Qa(;OCG+hw=?)1{(vJDM' );
+define( 'NONCE_KEY',        'Z8mnN0LgF@i/oVbR/-B@.=~/$03-Bk,LN9 i+ugSC= J#VQMrB:-erun6dqXPhiZ' );
+define( 'AUTH_SALT',        'B-(VfG*wT1-thHgvcg=>Zh8x_{I`c$$8;{]`Zj<?jSMq CHpGpqR|-#XU4n%NWi.' );
+define( 'SECURE_AUTH_SALT', 'XI]=V.(BC@Nl2)i)`*5A~&GriGE+[=Q)j|[KwN_b[o1+gbC-qh.$#d{^upYV+{4A' );
+define( 'LOGGED_IN_SALT',   '*=Co5O;Mg)iVGCD8?M&y|50%J^tg$jMqtSuC]_rm6iU3SToxVcy4A2.M,~>-Le$$' );
+define( 'NONCE_SALT',       '%$FL!g{~ie34U^j9F%T!|m(@Y;Fh[P-rnw!mQ:5?`hs+HJ(sHTSJml}6m#7)R}PE' );
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the documentation.
+ *
+ * @link https://wordpress.org/support/article/debugging-in-wordpress/
+ */
+define( 'WP_DEBUG', true );
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+  define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
This PR implements what was mentioned in issue #68. It adds a MariaDB database running in Docker so that users do not have to install a local database separately. This also makes it easier to start fresh instances of WordPressify.

I also added `.editorconfig` for consistency.