### PR TITLE
Improve GitHub Actions to better emulate real usage

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,13 +15,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: npm ci --no-audit
       - run: |
-          mkdir wpfy_global; \
-          cd wpfy_global; \
-          npm init -y; \
-          npm install ../; \
-          mkdir test; \
-          cd test; \
-          ../node_modules/.bin/wordpressify -y; \
-          for container in $( docker-compose ps -q ); do \
+          mkdir wpfy_global;
+          cd wpfy_global;
+          npm init -y;
+          npm install ../;
+          mkdir test;
+          cd test;
+          ../node_modules/.bin/wordpressify -y;
+          for container in $( docker-compose ps -q ); do
           docker exec $container echo "Hi!";
           done;

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,4 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm ci --no-audit
-      - run: ./installer/index.js -y
+      - run: |
+          mkdir wpfy_global; \
+          cd wpfy_global; \
+          npm init -y; \
+          npm install ../; \
+          mkdir test; \
+          cd test; \
+          ../node_modules/.bin/wordpressify -y; \
+          for container in $( docker-compose ps -q ); do \
+          docker exec $container echo "Hi!";
+          done;


### PR DESCRIPTION
Before this commit, GitHub Actions checked out the WordPressify
repository and ran the installer from there.  There are two problems
with this:

- No checks that containers were built successfuly
- All files get downloaded by the checkout process, rather than
  by the wordpressify command alone.

Now we match real usage more closely. And there are also checks in
place which make sure that the containers are running after
WordPressify installation is completed.