### PR TITLE
Make database persistent and abstract commands pertaining to Docker away from user

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
           npm install ../;
           mkdir test;
           cd test;
-          ../node_modules/.bin/wordpressify -y;
+          ../node_modules/.bin/wordpressify -y --keep-running;
           for container in $( docker-compose ps -q ); do
           docker exec $container echo "Hi!";
           done;

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,4 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm ci --no-audit
-      - run: ./installer/index.js -y
+      - run: |
+          mkdir wpfy_global;
+          cd wpfy_global;
+          npm init -y;
+          npm install ../;
+          mkdir test;
+          cd test;
+          ../node_modules/.bin/wordpressify -y;
+          for container in $( docker-compose ps -q ); do
+          docker exec $container echo "Hi!";
+          done;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - "3306"
     networks:
       - "default-network"
+    volumes:
+      - "persistent_db:/var/lib/mysql"
   wordpress:
     user: "${WPFY_UID}:${WPFY_GID}"
     build: .
@@ -44,3 +46,5 @@ services:
 networks:
   default-network:
     driver: bridge
+volumes:
+  persistent_db:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,6 +126,7 @@ function startContainers(done) {
 
 function buildContainers(done) {
 	execSync('docker-compose build', { stdio: 'inherit' });
+	done();
 }
 
 function stopContainers(done) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -113,7 +113,6 @@ function setupEnvironment(done) {
 
 function startContainers(done) {
 	execSync('docker-compose up -d', { stdio: 'inherit' });
-	containersStopped = false;
 	process.on('exit', stopContainers);
 	process.on('SIGINT', () => {
 	if (typeof devServerDone === 'function') {
@@ -131,7 +130,6 @@ function buildContainers(done) {
 
 function stopContainers(done) {
 	execSync('docker-compose down', { stdio: 'inherit' });
-	containersStopped = true;
 	if (typeof done === 'function') {
 		done();
 	}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,6 +131,10 @@ function startContainers(done) {
 	done();
 }
 
+function buildContainers(done) {
+	execSync('docker-compose build', { stdio: 'inherit' });
+}
+
 function stopContainers(done) {
 	execSync('docker-compose down', { stdio: 'inherit' });
 	containersStopped = true;
@@ -157,6 +161,7 @@ function restartWordPress(done) {
 	done();
 }
 
+exports['env:build'] = buildContainers
 exports['env:start'] = envStart;
 exports['env:stop'] = stopContainers;
 exports['env:rebuild'] = series(

--- a/installer/index.js
+++ b/installer/index.js
@@ -23,6 +23,7 @@ const version = require('../package.json').version;
 program
 	.version(version, '-v, --vers', 'output the current version')
 	.option('-y, --non-interactive', 'do not prompt for user input')
+	.option('--keep-running', 'keep containers running after installation')
 	.parse(process.argv);
 
 (async () => {
@@ -65,6 +66,6 @@ program
 		 * Runs all the functions with async/await.
 		 */
 		const run = require('./modules/run');
-		run();
+		run(program);
 	}
 })();

--- a/installer/modules/run.js
+++ b/installer/modules/run.js
@@ -206,12 +206,13 @@ module.exports = async (program) => {
 			spinner.succeed();
 
 			spinner.start('3. Installing WordPress and building Docker images...');
-			await execa('npm', ['run', 'env:start']);
-			spinner.succeed();
-
-			if (!program.keepRunning) {
-				await execa('npm', ['run', 'env:stop']);
+			if (program.keepRunning) {
+				await execa('npm', ['run', 'env:start']);
+			} else {
+				await execa('npm', ['run', 'env:build'])
 			}
+
+			spinner.succeed();
 
 			// Done.
 			printNextSteps();

--- a/installer/modules/run.js
+++ b/installer/modules/run.js
@@ -14,7 +14,7 @@ const handleError = require('./handleError.js');
 const clearConsole = require('./clearConsole.js');
 const printNextSteps = require('./printNextSteps.js');
 
-module.exports = () => {
+module.exports = async (program) => {
 	// Init.
 	clearConsole();
 
@@ -205,9 +205,13 @@ module.exports = () => {
 			await execa('npm', ['install']);
 			spinner.succeed();
 
-			spinner.start('3. Installing WordPress and building containers...');
+			spinner.start('3. Installing WordPress and building Docker images...');
 			await execa('npm', ['run', 'env:start']);
 			spinner.succeed();
+
+			if (!program.keepRunning) {
+				await execa('npm', ['run', 'env:stop']);
+			}
 
 			// Done.
 			printNextSteps();

--- a/installer/package.json
+++ b/installer/package.json
@@ -28,6 +28,7 @@
 		"wordpressify": "./installer/index.js"
 	},
 	"scripts": {
+		"env:build": "gulp env:build",
 		"env:start": "gulp env:start",
 		"env:stop": "gulp env:stop",
 		"env:rebuild": "gulp env:rebuild",


### PR DESCRIPTION
This resolves the issues mentioned in https://github.com/luangjokaj/wordpressify/pull/72#issuecomment-736653323

Now, running `npm run dev` is responsible for starting the containers. When the development server is stopped, containers are also stopped automatically.