### PR TITLE
Fix nginx config for wp query parameters

### DIFF
--- a/config/nginx/sites-enabled/wordpress
+++ b/config/nginx/sites-enabled/wordpress
@@ -10,7 +10,7 @@ server {
 	server_name _;
 
 	location / {
-		try_files $uri $uri/ /index.php$args;
+		try_files $uri $uri/ /index.php$is_args$args;
 	}
 
 	location ~ \.php$ {


### PR DESCRIPTION
This makes GET query parameters work with pretty wordpress permalinks.