### PR TITLE
Show wp errors in xdebug folder and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ npm-debug.log
 *.map
 *.log
 xdebug
+
+# Generated for specific a environment. These files are generated from
+# corresponding "*.in" files and they are specific for every machine, so they
+# should not be committed to the repository.
+Dockerfile
+.env
+config/php.ini

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ npm-debug.log
 *.log
 xdebug
 
-# Generated for specific a environment. These files are generated from
+# Generated for a specific environment. These files are generated from
 # corresponding "*.in" files and they are specific for every machine, so they
 # should not be committed to the repository.
 Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,9 @@ services:
       WORDPRESS_DB_PASSWORD: "${DB_PASSWORD}"
       WORDPRESS_DB_NAME: "${DB_NAME}"
       WORDPRESS_DEBUG: 1
-      WORDPRESS_CONFIG_EXTRA: "define( 'DISABLE_WP_CRON', true );"
+      WORDPRESS_CONFIG_EXTRA: |
+        define( 'DISABLE_WP_CRON', true );
+        define( 'WP_DEBUG_LOG', '/var/xdebug/wp-errors.log' );
     networks:
       - "default-network"
     volumes:


### PR DESCRIPTION
WordPress generates specific errors which are not shown in the usual PHP log. These were not displayed anywhere, now they will be in the `./xdebug` alongside PHP errors and any other xdebug stuff.